### PR TITLE
Updated Grunt JS && grunt.contrib.uglify due to NPM audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   },
   "devDependencies": {
     "@types/jquery": "^3.3.10",
-    "grunt": "^0.4.5",
+    "grunt": "^1.0.3",
     "grunt-autoprefixer": "^3.0.4",
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-cssmin": "^0.10.0",
     "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-sass": "^1.0.0",
-    "grunt-contrib-uglify": "^0.5.1",
+    "grunt-contrib-uglify": "^4.0.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-postcss": "^0.9.0"
   },


### PR DESCRIPTION
## After forking repo and running NPM
### Security Warnings on Outdated Packages

Both Grunt JS and `grunt-contrib-uglify` were outdated and npm recommended that at the very minimum those 2 packages be updated for security concerns. :+1: 
*See screenshot at the end*
I have tested out Grunt by running `grunt` and it still seems to run without any problems. :thinking: :smile: 

#### Additional Problems
Also `git-script` is causing 11 vulnerabilities, and appears to no longer being actively maintained. Due to it's old npm dependencies. You might want to look into either finding a new package, or _perhaps_ writing just some npm/node scripts to just run the `git` command for you :sunglasses: 

![npm_errors_log](https://user-images.githubusercontent.com/26460352/46773813-5159c600-cccd-11e8-8d37-a93cfee407d4.png)
